### PR TITLE
utf8proc 2.11.3 

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,3 +1,4 @@
+@echo on
 
 mkdir build
 if errorlevel 1 exit 1
@@ -10,9 +11,9 @@ cmake -G "NMake Makefiles" ^
   -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON ^
   -DBUILD_SHARED_LIBS:BOOL=ON ^
   "%SRC_DIR%"
-
 if errorlevel 1 exit 1
-cmake --build . --config Release
-cmake --build . --target install --config Release
 
-exit 0
+cmake --build . --config Release
+if errorlevel 1 exit 1
+cmake --build . --target install --config Release
+if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -ex
+
 mkdir build
 cd build
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,18 +1,20 @@
-{% set version = "2.6.1" %}
+{% set name = "utf8proc" %}
+{% set version = "2.11.3" %}
 
 package:
-  name: utf8proc
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://github.com/JuliaStrings/utf8proc/archive/v{{ version }}.tar.gz
-  sha256: 4c06a9dc4017e8a2438ef80ee371d45868bda2237a98b26554de7a95406b283b
+  url: https://github.com/JuliaStrings/{{ name }}/archive/v{{ version }}.tar.gz
+  sha256: abfed50b6d4da51345713661370290f4f4747263ee73dc90356299dfc7990c78
 
 build:
-  number: 1
+  number: 0
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - cmake
     - make  # [unix]
@@ -20,15 +22,13 @@ requirements:
 test:
   commands:
     - test -e $PREFIX/include/utf8proc.h  # [unix]
-    # no static version
-    # - test -e $PREFIX/lib/libutf8proc.a   # [unix]
     - test -e $PREFIX/lib/libutf8proc${SHLIB_EXT}  # [unix]
     - if not exist %LIBRARY_INC%\utf8proc.h exit 1 # [win]
     - if not exist %LIBRARY_LIB%\utf8proc.lib exit 1 # [win]
     - if not exist %LIBRARY_BIN%\utf8proc.dll exit 1 # [win]
 
 about:
-  home: https://juliastrings.github.io/utf8proc/
+  home: https://juliastrings.github.io/utf8proc
   license: MIT
   license_family: MIT
   license_file: LICENSE.md
@@ -36,7 +36,7 @@ about:
   description: |
     utf8proc is a small, clean C library that provides Unicode normalization, case-folding,
     and other operations for data in the UTF-8 encoding, supporting Unicode version 13.
-  doc_url: https://juliastrings.github.io/utf8proc/
+  doc_url: https://juliastrings.github.io/utf8proc
   dev_url: https://github.com/JuliaStrings/utf8proc
 
 extra:


### PR DESCRIPTION
utf8proc 2.11.3 

**Destination channel:** Defaults

### Links

- [PKG-13856]
- dev_url:        https://github.com/JuliaStrings/utf8proc/tree/v2.11.3

### Explanation of changes:

- new version number


[PKG-13856]: https://anaconda.atlassian.net/browse/PKG-13856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ